### PR TITLE
RHOSP: corrected port assignments to right path and shifted them from…

### DIFF
--- a/ansible/roles/layer2_rhosp_overcloud_deploy/templates/network-environment.yaml.j2
+++ b/ansible/roles/layer2_rhosp_overcloud_deploy/templates/network-environment.yaml.j2
@@ -6,12 +6,6 @@ resource_registry:
   OS::TripleO::Compute::Net::SoftwareConfig: ./nic-configs/compute.yaml
   OS::TripleO::Controller::Net::SoftwareConfig: ./nic-configs/controller.yaml
   OS::TripleO::Network::Management: /usr/share/openstack-tripleo-heat-templates/network/management.yaml
-  OS::TripleO::Controller::Ports::ManagementPort:   /usr/share/openstack-tripleo-heat-templates/network/ports/management.yaml
-  OS::TripleO::Compute::Ports::ManagementPort:      /usr/share/openstack-tripleo-heat-templates/network/ports/management.yaml
-  OS::TripleO::CephStorage::Ports::ManagementPort:  /usr/share/openstack-tripleo-heat-templates/network/ports/management.yaml
-  OS::TripleO::SwiftStorage::Ports::ManagementPort: /usr/share/openstack-tripleo-heat-templates/network/ports/management.yaml
-  OS::TripleO::BlockStorage::Ports::ManagementPort: /usr/share/openstack-tripleo-heat-templates/network/ports/management.yaml
-
 
 parameter_defaults:
   PublicVirtualFixedIPs: [{'ip_address':'{{ hostvars['openstack'].vm_nics[0].ip }}'}]

--- a/ansible/roles/layer2_rhosp_overcloud_deploy/templates/network-isolation.yaml.j2
+++ b/ansible/roles/layer2_rhosp_overcloud_deploy/templates/network-isolation.yaml.j2
@@ -2,63 +2,63 @@
 # traffic and configure each role to assign ports (related
 # to that role) on these networks.
 resource_registry:
-  OS::TripleO::Network::External: ../network/external.yaml
-  OS::TripleO::Network::InternalApi: ../network/internal_api.yaml
-  OS::TripleO::Network::StorageMgmt: ../network/storage_mgmt.yaml
-  OS::TripleO::Network::Storage: ../network/storage.yaml
-  OS::TripleO::Network::Tenant: ../network/tenant.yaml
+  OS::TripleO::Network::External: /usr/share/openstack-tripleo-heat-templates/network/external.yaml
+  OS::TripleO::Network::InternalApi: /usr/share/openstack-tripleo-heat-templates/network/internal_api.yaml
+  OS::TripleO::Network::StorageMgmt: /usr/share/openstack-tripleo-heat-templates/network/storage_mgmt.yaml
+  OS::TripleO::Network::Storage: /usr/share/openstack-tripleo-heat-templates/network/storage.yaml
+  OS::TripleO::Network::Tenant: /usr/share/openstack-tripleo-heat-templates/network/tenant.yaml
   # Management network is optional and disabled by default.
   # To enable it, include environments/network-management.yaml
-  #OS::TripleO::Network::Management: ../network/management.yaml
+  #OS::TripleO::Network::Management: /usr/share/openstack-tripleo-heat-templates/network/management.yaml
 
   # Port assignments for the VIPs
-  OS::TripleO::Network::Ports::ExternalVipPort: ../network/ports/external.yaml
-  OS::TripleO::Network::Ports::InternalApiVipPort: ../network/ports/internal_api.yaml
-  OS::TripleO::Network::Ports::StorageVipPort: ../network/ports/storage.yaml
-  OS::TripleO::Network::Ports::StorageMgmtVipPort: ../network/ports/storage_mgmt.yaml
-  OS::TripleO::Network::Ports::RedisVipPort: ../network/ports/vip.yaml
+  OS::TripleO::Network::Ports::ExternalVipPort: /usr/share/openstack-tripleo-heat-templates/network/ports/external.yaml
+  OS::TripleO::Network::Ports::InternalApiVipPort: /usr/share/openstack-tripleo-heat-templates/network/ports/internal_api.yaml
+  OS::TripleO::Network::Ports::StorageVipPort: /usr/share/openstack-tripleo-heat-templates/network/ports/storage.yaml
+  OS::TripleO::Network::Ports::StorageMgmtVipPort: /usr/share/openstack-tripleo-heat-templates/network/ports/storage_mgmt.yaml
+  OS::TripleO::Network::Ports::RedisVipPort: /usr/share/openstack-tripleo-heat-templates/network/ports/vip.yaml
 
   # Port assignments for the controller role
-  OS::TripleO::Controller::Ports::ExternalPort: ../network/ports/external.yaml
-  OS::TripleO::Controller::Ports::InternalApiPort: ../network/ports/internal_api.yaml
-  OS::TripleO::Controller::Ports::StoragePort: ../network/ports/storage.yaml
-  OS::TripleO::Controller::Ports::StorageMgmtPort: ../network/ports/storage_mgmt.yaml
-  OS::TripleO::Controller::Ports::TenantPort: ../network/ports/tenant.yaml
-  OS::TripleO::Controller::Ports::ManagementPort: ../network/ports/management.yaml
+  OS::TripleO::Controller::Ports::ExternalPort: /usr/share/openstack-tripleo-heat-templates/network/ports/external.yaml
+  OS::TripleO::Controller::Ports::InternalApiPort: /usr/share/openstack-tripleo-heat-templates/network/ports/internal_api.yaml
+  OS::TripleO::Controller::Ports::StoragePort: /usr/share/openstack-tripleo-heat-templates/network/ports/storage.yaml
+  OS::TripleO::Controller::Ports::StorageMgmtPort: /usr/share/openstack-tripleo-heat-templates/network/ports/storage_mgmt.yaml
+  OS::TripleO::Controller::Ports::TenantPort: /usr/share/openstack-tripleo-heat-templates/network/ports/tenant.yaml
+  OS::TripleO::Controller::Ports::ManagementPort: /usr/share/openstack-tripleo-heat-templates/network/ports/management.yaml
 
   # Port assignments for the compute role
-  OS::TripleO::Compute::Ports::ExternalPort: ../network/ports/external.yaml
-  OS::TripleO::Compute::Ports::InternalApiPort: ../network/ports/internal_api.yaml
-  OS::TripleO::Compute::Ports::StoragePort: ../network/ports/storage.yaml
+  OS::TripleO::Compute::Ports::ExternalPort: /usr/share/openstack-tripleo-heat-templates/network/ports/external.yaml
+  OS::TripleO::Compute::Ports::InternalApiPort: /usr/share/openstack-tripleo-heat-templates/network/ports/internal_api.yaml
+  OS::TripleO::Compute::Ports::StoragePort: /usr/share/openstack-tripleo-heat-templates/network/ports/storage.yaml
 {% if current_lifecycle_env.osp_storage_backend == 'ceph_hyperconverged' %}
-  OS::TripleO::Compute::Ports::StorageMgmtPort: ../network/ports/storage_mgmt.yaml
+  OS::TripleO::Compute::Ports::StorageMgmtPort: /usr/share/openstack-tripleo-heat-templates/network/ports/storage_mgmt.yaml
 {% else %}
-  OS::TripleO::Compute::Ports::StorageMgmtPort: ../network/ports/noop.yaml
+  OS::TripleO::Compute::Ports::StorageMgmtPort: /usr/share/openstack-tripleo-heat-templates/network/ports/noop.yaml
 {% endif %}
-  OS::TripleO::Compute::Ports::TenantPort: ../network/ports/tenant.yaml
-  OS::TripleO::Compute::Ports::ManagementPort: ../network/ports/management.yaml
+  OS::TripleO::Compute::Ports::TenantPort: /usr/share/openstack-tripleo-heat-templates/network/ports/tenant.yaml
+  OS::TripleO::Compute::Ports::ManagementPort: /usr/share/openstack-tripleo-heat-templates/network/ports/management.yaml
 
   # Port assignments for the ceph storage role
-  OS::TripleO::CephStorage::Ports::ExternalPort: ../network/ports/noop.yaml
-  OS::TripleO::CephStorage::Ports::InternalApiPort: ../network/ports/noop.yaml
-  OS::TripleO::CephStorage::Ports::StoragePort: ../network/ports/storage.yaml
-  OS::TripleO::CephStorage::Ports::StorageMgmtPort: ../network/ports/storage_mgmt.yaml
-  OS::TripleO::CephStorage::Ports::TenantPort: ../network/ports/noop.yaml
-  #OS::TripleO::CephStorage::Ports::ManagementPort: ../network/ports/management.yaml
+  OS::TripleO::CephStorage::Ports::ExternalPort: /usr/share/openstack-tripleo-heat-templates/network/ports/noop.yaml
+  OS::TripleO::CephStorage::Ports::InternalApiPort: /usr/share/openstack-tripleo-heat-templates/network/ports/noop.yaml
+  OS::TripleO::CephStorage::Ports::StoragePort: /usr/share/openstack-tripleo-heat-templates/network/ports/storage.yaml
+  OS::TripleO::CephStorage::Ports::StorageMgmtPort: /usr/share/openstack-tripleo-heat-templates/network/ports/storage_mgmt.yaml
+  OS::TripleO::CephStorage::Ports::TenantPort: /usr/share/openstack-tripleo-heat-templates/network/ports/noop.yaml
+  #OS::TripleO::CephStorage::Ports::ManagementPort: /usr/share/openstack-tripleo-heat-templates/network/ports/management.yaml
 
   # Port assignments for the swift storage role
-  OS::TripleO::SwiftStorage::Ports::ExternalPort: ../network/ports/noop.yaml
-  OS::TripleO::SwiftStorage::Ports::InternalApiPort: ../network/ports/internal_api.yaml
-  OS::TripleO::SwiftStorage::Ports::StoragePort: ../network/ports/storage.yaml
-  OS::TripleO::SwiftStorage::Ports::StorageMgmtPort: ../network/ports/storage_mgmt.yaml
-  OS::TripleO::SwiftStorage::Ports::TenantPort: ../network/ports/noop.yaml
-  #OS::TripleO::SwiftStorage::Ports::ManagementPort: ../network/ports/management.yaml
+  OS::TripleO::SwiftStorage::Ports::ExternalPort: /usr/share/openstack-tripleo-heat-templates/network/ports/noop.yaml
+  OS::TripleO::SwiftStorage::Ports::InternalApiPort: /usr/share/openstack-tripleo-heat-templates/network/ports/internal_api.yaml
+  OS::TripleO::SwiftStorage::Ports::StoragePort: /usr/share/openstack-tripleo-heat-templates/network/ports/storage.yaml
+  OS::TripleO::SwiftStorage::Ports::StorageMgmtPort: /usr/share/openstack-tripleo-heat-templates/network/ports/storage_mgmt.yaml
+  OS::TripleO::SwiftStorage::Ports::TenantPort: /usr/share/openstack-tripleo-heat-templates/network/ports/noop.yaml
+  #OS::TripleO::SwiftStorage::Ports::ManagementPort: /usr/share/openstack-tripleo-heat-templates/network/ports/management.yaml
 
   # Port assignments for the block storage role
-  OS::TripleO::BlockStorage::Ports::ExternalPort: ../network/ports/noop.yaml
-  OS::TripleO::BlockStorage::Ports::InternalApiPort: ../network/ports/internal_api.yaml
-  OS::TripleO::BlockStorage::Ports::StoragePort: ../network/ports/storage.yaml
-  OS::TripleO::BlockStorage::Ports::StorageMgmtPort: ../network/ports/storage_mgmt.yaml
-  OS::TripleO::BlockStorage::Ports::TenantPort: ../network/ports/noop.yaml
-  #OS::TripleO::BlockStorage::Ports::ManagementPort: ../network/ports/management.yaml
+  OS::TripleO::BlockStorage::Ports::ExternalPort: /usr/share/openstack-tripleo-heat-templates/network/ports/noop.yaml
+  OS::TripleO::BlockStorage::Ports::InternalApiPort: /usr/share/openstack-tripleo-heat-templates/network/ports/internal_api.yaml
+  OS::TripleO::BlockStorage::Ports::StoragePort: /usr/share/openstack-tripleo-heat-templates/network/ports/storage.yaml
+  OS::TripleO::BlockStorage::Ports::StorageMgmtPort: /usr/share/openstack-tripleo-heat-templates/network/ports/storage_mgmt.yaml
+  OS::TripleO::BlockStorage::Ports::TenantPort: /usr/share/openstack-tripleo-heat-templates/network/ports/noop.yaml
+  #OS::TripleO::BlockStorage::Ports::ManagementPort: /usr/share/openstack-tripleo-heat-templates/network/ports/management.yaml
 


### PR DESCRIPTION
… network-environment.yaml.j2 to network-isolation.yaml.j2 where they should be